### PR TITLE
Add CI Workflow

### DIFF
--- a/.github/cmake.yml
+++ b/.github/cmake.yml
@@ -1,0 +1,105 @@
+#******************************************************************************
+#*Copyright (C) 2023 by Salvador Z                                            *
+#*                                                                            *
+#*****************************************************************************/
+#*
+#*@author Salvador Z
+#*@brief GitHub workflow to configure an automated process to run one or more jobs
+#*
+# Template for all jobs
+name: GITHUB-CI
+
+on:
+  push:
+    branches: [ "develop" ]
+  pull_request:
+    branches:
+      - develop
+    types:
+      - closed
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Debug
+
+jobs:
+  configure:
+    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
+    # You can convert this to a matrix build if you need cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: self-hosted
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Configure CMake project
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+
+  clang-format:
+    runs-on: self-hosted
+    needs: configure
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Run clang-format
+        working-directory: ./build/
+        run: make clang-format
+
+  build:
+    runs-on: self-hosted
+    needs: configure
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Build project
+        working-directory: ./build/
+        run: make -j$(nproc --all) all
+
+  test:
+    runs-on: self-hosted
+    needs: build
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Run tests
+        working-directory: ./build/
+        run: ctest -vv
+
+  coverage:
+    runs-on: self-hosted
+    needs: build
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Enable coverage
+        working-directory: ./build/
+        run: |
+          cmake -DENABLE_COVERAGE=ON ..
+          make clean
+          make -j$(nproc --all) all
+          make test-coverage
+
+  deploy:
+    runs-on: self-hosted
+    needs: build
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Deploy artifacts
+        working-directory: ./build/
+        run: |
+          echo "Build succeeded, archiving artifacts..."
+          make -j$(nproc --all) install
+        artifacts:
+          name: bow_artifacts
+          expires-in: 1 day
+          paths:
+            - artifacts/


### PR DESCRIPTION
# Description

Adding a GitHub workflow to configure an automated process to run 6 jobs in a self-hosted runner

# Validation

This CI pipeline includes a `clang-format` job and `test` using **Ctest** from **CMAKE**. Algo generates an **_HTML report_** with Code coverage using `gcov` and `lcov`

- [X] test_strio_lib
- [X] 100% Branches on Code Coverage

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [-] Any dependent changes have been merged and published in downstream modules
