### PR TITLE
Disable Code Coverage CMake Module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ endif()
 option(ENABLE_FORMAT  "Enable format analysis with clang-format" ON)
 option(ENABLE_CODEGCOV  "Enable coverage reporting"              OFF)
 # Automated Code Coverage using GCOV, LCOV and GENHTML
-option(ENABLE_COVERAGE  "Enable code coverage report and HTML  " ON)
+option(ENABLE_COVERAGE  "Enable code coverage report and HTML  " OFF)
 
 ### General Configuration ###
 


### PR DESCRIPTION
# Description

Disable the `ENABLE_COVERAGE` option on **`CMakeLists.txt`**

# Change request
#4 Mention the reason of being received the incorrect flags on Release build type.

# Validation

This CI pipeline now runs two build types with proper flags

- [X] Release build type tests
- [X] Debug build type test+coverage

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings